### PR TITLE
Make the applied filter find a shadow-dom-nested filter-dropdown better

### DIFF
--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -145,7 +145,8 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 				if (child.nodeName === DROPDOWN_NAME) {
 					return child;
 				}
-				const t = child.querySelector('d2l-filter-dropdown');
+				const nestedChildren = getComposedChildren(child) || [];
+				const t = nestedChildren.find(x => x.nodeName === DROPDOWN_NAME);
 				if (t) {
 					return t;
 				}


### PR DESCRIPTION
The shadow-dom boundary was causing some issues for finding the dropdown filter wrapped in another component, this fixes that

Ideally this goes in after https://github.com/BrightspaceUILabs/facet-filter-sort/pull/63 so that it can have proper linting