### PR TITLE
Removed important from hidden subtle button

### DIFF
--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -75,7 +75,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			}
 
 			[hidden] {
-				display: none !important;
+				display: none;
 			}
 		`];
 	}


### PR DESCRIPTION
## Related PRs

This PR https://github.com/BrightspaceUILabs/facet-filter-sort/pull/57 added `!important` when it shouldn't have.

## Rally

https://rally1.rallydev.com/#/detail/userstory/406501674732?fdp=true

