### PR TITLE
DE40799 - Stop the d2l-tab-panel-selected event from propagating out of the filter

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js
@@ -201,6 +201,7 @@ class FilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitElemen
 	}
 
 	_dispatchSelected() {
+		// Event propagation stopped in d2l-filter-dropdown
 		this.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
 			detail: {
 				categoryKey: this.key

--- a/components/d2l-filter-dropdown/d2l-filter-dropdown.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown.js
@@ -137,6 +137,7 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 
 	attached()  {
 		this.addEventListener('d2l-dropdown-close', this._handleDropdownClose);
+		this.addEventListener('d2l-tab-panel-selected', this._stopTabPanelSelectedEvent);
 	}
 
 	clearFilters() {
@@ -157,6 +158,7 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 
 	detached() {
 		this.removeEventListener('d2l-dropdown-close', this._handleDropdownClose);
+		this.removeEventListener('d2l-tab-panel-selected', this._stopTabPanelSelectedEvent);
 	}
 
 	focus() {
@@ -196,6 +198,11 @@ class D2LFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.FilterDropd
 
 	_localizeOrAlt(altText, ...args) {
 		return altText ? altText : this.localize(...args);
+	}
+
+	// Must be done here (instead of d2l-filter-dropdown-category) as the d2l-dropdown-tabs component needs to receive it
+	_stopTabPanelSelectedEvent(e) {
+		e.stopPropagation();
 	}
 }
 


### PR DESCRIPTION
`master` version of https://github.com/BrightspaceUILabs/facet-filter-sort/pull/70