### PR TITLE
Revert Shrinkwrap Support

### DIFF
--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -61,6 +61,11 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 				color: var(--d2l-color-corundum);
 			}
 
+			#d2l-clear-filters-button {
+				margin-left: 3px;
+				margin-right: 3px;
+			}
+
 			#d2l-list-holder {
 				flex: 1;
 			}
@@ -133,10 +138,6 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 		const filters = this._selectedEntries && this._selectedEntries.length > 0 ?
 			html`<d2l-labs-multi-select-list
 				collapsable
-				shrinkwrap
-				?show-clear-list="${this._selectedEntries.length >= CLEAR_FILTERS_THRESHOLD}"
-				clear-list-button-text="${this.localize('clearFilters')}"
-				@d2l-multi-select-list-clear-list-clicked="${this._clearFiltersClicked}"
 				aria-labelledby="d2l-applied-filters-label"
 			>
 				${(this._selectedEntries || []).map((x, index) => html`
@@ -156,6 +157,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.localize('appliedFilters')}</span>
 				<div id="d2l-list-holder">
 					${filters}
+					<d2l-button-subtle id="d2l-clear-filters-button" text="${this.localize('clearFilters')}" ?hidden="${this._selectedEntries.length < CLEAR_FILTERS_THRESHOLD}" @click="${this._clearFiltersClicked}"></d2l-button-subtle>
 				</div>
 			</div>
 		`;

--- a/demo/d2l-applied-filters/d2l-applied-filters.html
+++ b/demo/d2l-applied-filters/d2l-applied-filters.html
@@ -27,10 +27,10 @@
 				<template>
 					<d2l-filter-dropdown id="filter" total-selected-option-count="2">
 						<d2l-filter-dropdown-category key="1" category-text="Cat1">
-							<d2l-filter-dropdown-option selected text="Option 1-1" value="1"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1-2" value="2"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1-3" value="3"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1-4" value="4"></d2l-filter-dropdown-option>
+							<d2l-filter-dropdown-option selected text="Option 1 - 1" value="1"></d2l-filter-dropdown-option>
+							<d2l-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-filter-dropdown-option>
+							<d2l-filter-dropdown-option text="Option 1 - 3" value="3"></d2l-filter-dropdown-option>
+							<d2l-filter-dropdown-option text="Option 1 - 4" value="4"></d2l-filter-dropdown-option>
 						</d2l-filter-dropdown-category>
 						<d2l-filter-dropdown-category key="2" category-text="Cat2">
 							<d2l-filter-dropdown-option selected text="Option 2 - 1" value="1"></d2l-filter-dropdown-option>

--- a/test/d2l-applied-filters/d2l-applied-filters.html
+++ b/test/d2l-applied-filters/d2l-applied-filters.html
@@ -103,21 +103,21 @@
 				});
 
 				test('clear filters button is hidden when 3 filters are applied', function() {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
-					assert.equal(filterList.hasAttribute('show-clear-list'), false);
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
+					assert.equal(clearFilters.hidden, true);
 				});
 				test('selecting a 4th filter reveals the clear filters button', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 					options[1].click();
 
 					afterNextRender(options[1], () => {
-						assert.equal(filterList.hasAttribute('show-clear-list'), true);
+						assert.equal(clearFilters.hidden, false);
 						done();
 					});
 				});
 				test('selecting a 4th filter then removing it hides the clear filters button', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 					options[1].click();
 
@@ -125,13 +125,13 @@
 						options[1].deselect();
 
 						afterNextRender(options[1], () => {
-							assert.equal(filterList.hasAttribute('show-clear-list'), false);
+							assert.equal(clearFilters.hidden, true);
 							done();
 						});
 					});
 				});
 				test('clear filters button is visible when all filters are applied', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 
 					options[1].click();
@@ -142,12 +142,12 @@
 					options[8].click();
 
 					afterNextRender(options[1], () => {
-						assert.equal(filterList.hasAttribute('show-clear-list'), true);
+						assert.equal(clearFilters.hidden, false);
 						done();
 					});
 				});
 				test('clear filters button is hidden when 0 filters are applied', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 
 					options[0].deselect();
@@ -155,29 +155,28 @@
 					options[6].deselect();
 
 					afterNextRender(options[0], () => {
-						assert.equal(filterList.hasAttribute('show-clear-list'), false);
+						assert.equal(clearFilters.hidden, true);
 						done();
 					});
 				});
 				test('clear filters button is hidden when 1 filters is applied', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 
 					options[0].deselect();
 					options[3].deselect();
 
 					afterNextRender(options[0], () => {
-						assert.equal(filterList.hasAttribute('show-clear-list'), false);
+						assert.equal(clearFilters.hidden, true);
 						done();
 					});
 				});
 				test('selecting a 4th filter & clicking clear filters fires a d2l-filter-dropdown-cleared event', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 
 					const handleClearEvent = () => {
 						document.removeEventListener('d2l-filter-dropdown-cleared', handleClearEvent);
-						assert.equal('true', 'true');
 						done();
 					};
 
@@ -185,26 +184,23 @@
 
 					options[1].click();
 
-					afterNextRender(filterList, () => {
-						const buttons = Array.from(filterList.shadowRoot.querySelectorAll('d2l-button-subtle'));
-						const clearFilters = buttons.find(a => a.getAttribute('text') === 'Clear filters' && !a.classList.contains('hide'));
+					afterNextRender(clearFilters, () => {
 						clearFilters.click();
 					});
 				});
-				test('selecting a 4th filter & clicking clear filters removes filters', function(done) {
-					const filterList = appliedFilters.shadowRoot.querySelector('d2l-labs-multi-select-list');
+				test('selecting a 4th filter & clicking clear filters removes filters & hides clear filters button', function(done) {
+					const clearFilters = appliedFilters.shadowRoot.querySelector('#d2l-clear-filters-button');
 					const options = dropdown.querySelectorAll('d2l-filter-dropdown-option');
 
 					options[1].click();
 
-					afterNextRender(filterList, () => {
-						const buttons = Array.from(filterList.shadowRoot.querySelectorAll('d2l-button-subtle'));
-						const clearFilters = buttons.find(a => a.getAttribute('text') === 'Clear filters' && !a.classList.contains('hide'));
+					afterNextRender(clearFilters, () => {
 						clearFilters.click();
 
-						afterNextRender(filterList, () => {
+						afterNextRender(clearFilters, () => {
 							const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');
 							assert.equal(filters.length, 0);
+							assert.equal(clearFilters.hidden, true);
 							done();
 						});
 					});


### PR DESCRIPTION
Reverting changes to pull shrinkwrap support out, since we had an unresolvable issue in Firefox with the multi select when used in combination with the filters.

Hoping we don't need to revert multi-select, since everything in there should be transparent to this component if we disable the support.