### PR TITLE
fix: don't specify node_modules in demo component imports

### DIFF
--- a/demo/d2l-applied-filters/d2l-applied-filters.html
+++ b/demo/d2l-applied-filters/d2l-applied-filters.html
@@ -6,8 +6,8 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
-			import '/node_modules/@brightspace-ui/core/components/typography/typography.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/typography/typography.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';

--- a/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
+++ b/demo/d2l-filter-dropdown/d2l-filter-dropdown.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
 			import '../../components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';

--- a/demo/d2l-search-facets/d2l-search-facets.html
+++ b/demo/d2l-search-facets/d2l-search-facets.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../components/d2l-search-facets/d2l-search-facets.js';
 			import '../../components/d2l-search-facets/d2l-search-facets-grouping.js';
 			import '../../components/d2l-search-facets/d2l-search-facets-option.js';

--- a/demo/d2l-search-results-count/d2l-search-results-count.html
+++ b/demo/d2l-search-results-count/d2l-search-results-count.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../components/d2l-search-results-count/d2l-search-results-count.js';
 		</script>
 	</head>

--- a/demo/d2l-sort-by-dropdown/d2l-sort-by-dropdown.html
+++ b/demo/d2l-sort-by-dropdown/d2l-sort-by-dropdown.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
 			import '../../components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
 		</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
-			import '/node_modules/@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/demo/demo-page.js';
 		</script>
 	</head>
 	<body class="d2l-typography">


### PR DESCRIPTION
Should fix an issue where some components used by demo pages and the component itself results in an attempt to register the same custom element twice, resulting in non-functioning demos.