### PR TITLE
US120434 Ability to change the label on d2l-applied-filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 cache:
   npm: false
 language: node_js
-node_js: node
+node_js: 14
 addons:
   chrome: stable
 script:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ NOTE: This component uses the `slotchange` event and so will not work if you req
 
 <img src="/images/d2l-applied-filters.png?raw=true" width="450">
 
+#### Attributes
+
+- `for`: The id of the `d2l-filter-dropdown` you want to track.
+- `applied-filters-label-text`: (optional) The text displayed in this component's label. Defaults to "Applied Filters:".
+
 #### Usage
 
 Set the `for` param to be the id of the `d2l-filter-dropdown` that you want to track.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ NOTE: This component uses the `slotchange` event and so will not work if you req
 #### Attributes
 
 - `for`: The id of the `d2l-filter-dropdown` you want to track.
-- `applied-filters-label-text`: (optional) The text displayed in this component's label. Defaults to "Applied Filters:".
+- `label-text`: (optional) The text displayed in this component's label. Defaults to "Applied Filters:".
 
 #### Usage
 

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -25,7 +25,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			/**
 			 * Optional: The text displayed in this component's label. Default: "Applied Filters:"
 			 */
-			appliedFiltersLabelText: { type: String, attribute: 'applied-filters-label-text' },
+			labelText: { type: String, attribute: 'label-text' },
 			_entries: { type: Array },
 			_selectedEntries: { type: Array },
 			_target: { type: Object },
@@ -126,7 +126,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 	constructor() {
 		super();
-		this.appliedFiltersLabelText = '';
+		this.labelText = '';
 
 		this._clearFiltersClicked = this._clearFiltersClicked.bind(this);
 		this._clearSelected = this._clearSelected.bind(this);
@@ -160,7 +160,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 		return html`
 			<div class="d2l-applied-filters-wrapper">
-				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.appliedFiltersLabelText || this.localize('appliedFilters')}</span>
+				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.labelText || this.localize('appliedFilters')}</span>
 				<div id="d2l-list-holder">
 					${filters}
 					<d2l-button-subtle id="d2l-clear-filters-button" text="${this.localize('clearFilters')}" ?hidden="${this._selectedEntries.length < CLEAR_FILTERS_THRESHOLD}" @click="${this._clearFiltersClicked}"></d2l-button-subtle>

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -22,6 +22,10 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			 * REQUIRED: The id of the "d2l-filter-dropdown" that you want to track
 			 */
 			for: { type: String },
+			/**
+			 * Optional: The text displayed in this component's label. Default: "Applied Filters:"
+			 */
+			appliedFilterLabelText: { type: String, attribute: 'applied-filter-label-text' },
 			_entries: { type: Array },
 			_selectedEntries: { type: Array },
 			_target: { type: Object },
@@ -122,6 +126,8 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 	constructor() {
 		super();
+		this.appliedFilterLabelText = '';
+
 		this._clearFiltersClicked = this._clearFiltersClicked.bind(this);
 		this._clearSelected = this._clearSelected.bind(this);
 		this._setSelectedOptions = this._setSelectedOptions.bind(this);
@@ -154,7 +160,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 		return html`
 			<div class="d2l-applied-filters-wrapper">
-				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.localize('appliedFilters')}</span>
+				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.appliedFilterLabelText || this.localize('appliedFilters')}</span>
 				<div id="d2l-list-holder">
 					${filters}
 					<d2l-button-subtle id="d2l-clear-filters-button" text="${this.localize('clearFilters')}" ?hidden="${this._selectedEntries.length < CLEAR_FILTERS_THRESHOLD}" @click="${this._clearFiltersClicked}"></d2l-button-subtle>

--- a/components/d2l-applied-filters/d2l-applied-filters.js
+++ b/components/d2l-applied-filters/d2l-applied-filters.js
@@ -25,7 +25,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			/**
 			 * Optional: The text displayed in this component's label. Default: "Applied Filters:"
 			 */
-			appliedFilterLabelText: { type: String, attribute: 'applied-filter-label-text' },
+			appliedFiltersLabelText: { type: String, attribute: 'applied-filters-label-text' },
 			_entries: { type: Array },
 			_selectedEntries: { type: Array },
 			_target: { type: Object },
@@ -126,7 +126,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 	constructor() {
 		super();
-		this.appliedFilterLabelText = '';
+		this.appliedFiltersLabelText = '';
 
 		this._clearFiltersClicked = this._clearFiltersClicked.bind(this);
 		this._clearSelected = this._clearSelected.bind(this);
@@ -160,7 +160,7 @@ class D2lAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 		return html`
 			<div class="d2l-applied-filters-wrapper">
-				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.appliedFilterLabelText || this.localize('appliedFilters')}</span>
+				<span id="d2l-applied-filters-label" class="d2l-applied-filters-applied-filters-label d2l-body-compact">${this.appliedFiltersLabelText || this.localize('appliedFilters')}</span>
 				<div id="d2l-list-holder">
 					${filters}
 					<d2l-button-subtle id="d2l-clear-filters-button" text="${this.localize('clearFilters')}" ?hidden="${this._selectedEntries.length < CLEAR_FILTERS_THRESHOLD}" @click="${this._clearFiltersClicked}"></d2l-button-subtle>

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -18,6 +18,12 @@
           "attribute": "for",
           "description": "REQUIRED: The id of the \"d2l-filter-dropdown\" that you want to track",
           "type": "string"
+        },
+        {
+          "name": "appliedFiltersLabelText",
+          "attribute": "applied-filters-label-text",
+          "description": "The text displayed in this component's label. Default: \"Applied Filters:\"",
+          "type": "string"
         }
       ]
     },

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -20,8 +20,8 @@
           "type": "string"
         },
         {
-          "name": "appliedFiltersLabelText",
-          "attribute": "applied-filters-label-text",
+          "name": "labelText",
+          "attribute": "label-text",
           "description": "The text displayed in this component's label. Default: \"Applied Filters:\"",
           "type": "string"
         }

--- a/demo/d2l-applied-filters/d2l-applied-filters.html
+++ b/demo/d2l-applied-filters/d2l-applied-filters.html
@@ -80,7 +80,7 @@
 			<h2>d2l-applied-filters with custom label text</h2>
 
 			<d2l-demo-snippet>
-				<d2l-applied-filters for="filter" applied-filters-label-text="Filters selected:">
+				<d2l-applied-filters for="filter" label-text="Filters selected:">
 				</d2l-applied-filters>
 			</d2l-demo-snippet>
 

--- a/demo/d2l-applied-filters/d2l-applied-filters.html
+++ b/demo/d2l-applied-filters/d2l-applied-filters.html
@@ -80,7 +80,7 @@
 			<h2>d2l-applied-filters with custom label text</h2>
 
 			<d2l-demo-snippet>
-				<d2l-applied-filters for="filter" applied-filter-label-text="Filters selected:">
+				<d2l-applied-filters for="filter" applied-filters-label-text="Filters selected:">
 				</d2l-applied-filters>
 			</d2l-demo-snippet>
 

--- a/demo/d2l-applied-filters/d2l-applied-filters.html
+++ b/demo/d2l-applied-filters/d2l-applied-filters.html
@@ -21,60 +21,67 @@
 
 		<d2l-demo-page page-title="d2l-applied-filters">
 
-			<h2>Basic d2l-filter-dropdown with hardcoded data and events console logged</h2>
+			<h2>Use this dropdown filter to control the applied filters:</h2>
+
+			<d2l-filter-dropdown id="filter" total-selected-option-count="2">
+				<d2l-filter-dropdown-category key="1" category-text="Cat1">
+					<d2l-filter-dropdown-option selected text="Option 1 - 1" value="1"></d2l-filter-dropdown-option>
+					<d2l-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-filter-dropdown-option>
+					<d2l-filter-dropdown-option text="Option 1 - 3" value="3"></d2l-filter-dropdown-option>
+					<d2l-filter-dropdown-option text="Option 1 - 4" value="4"></d2l-filter-dropdown-option>
+				</d2l-filter-dropdown-category>
+				<d2l-filter-dropdown-category key="2" category-text="Cat2">
+					<d2l-filter-dropdown-option selected text="Option 2 - 1" value="1"></d2l-filter-dropdown-option>
+					<d2l-filter-dropdown-option text="Option 2 - 2" value="2"></d2l-filter-dropdown-option>
+					<d2l-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-filter-dropdown-option>
+				</d2l-filter-dropdown-category>
+			</d2l-filter-dropdown>
+			<script>
+				const filter = document.querySelector('#filter');
+				filter.addEventListener('d2l-filter-dropdown-close', (e) => {
+					logEvent(e, 'Filter dropdown closed!');
+				});
+				filter.addEventListener('d2l-filter-dropdown-cleared', (e) => {
+					logEvent(e, 'Filters clear button clicked!');
+				});
+				filter.addEventListener('d2l-filter-dropdown-category-selected', (e) => {
+					logEvent(e, 'Filter category tab selected!');
+				});
+				filter.addEventListener('d2l-filter-dropdown-category-searched', (e) => {
+					logEvent(e, 'Filter category searched!');
+				});
+				filter.addEventListener('d2l-filter-dropdown-category-slotchange', (e) => {
+					logEvent(e, 'Filter category slotchange!');
+				});
+				filter.addEventListener('d2l-filter-dropdown-option-change', (e) => {
+					logEvent(e, 'Filter option clicked!');
+					if (e.detail.selected) {
+						filter.totalSelectedOptionCount++;
+					} else {
+						filter.totalSelectedOptionCount--;
+					}
+				});
+				/* eslint-disable no-console */
+				function logEvent(e, text) {
+					console.group(text);
+					console.log('event', e);
+					if (e.detail) console.log('detail', e.detail);
+					console.groupEnd();
+				}
+				/* eslint-enable no-console */
+			</script>
+
+			<h2>d2l-applied-filters with default label text</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-filter-dropdown id="filter" total-selected-option-count="2">
-						<d2l-filter-dropdown-category key="1" category-text="Cat1">
-							<d2l-filter-dropdown-option selected text="Option 1 - 1" value="1"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1 - 3" value="3"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 1 - 4" value="4"></d2l-filter-dropdown-option>
-						</d2l-filter-dropdown-category>
-						<d2l-filter-dropdown-category key="2" category-text="Cat2">
-							<d2l-filter-dropdown-option selected text="Option 2 - 1" value="1"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 2 - 2" value="2"></d2l-filter-dropdown-option>
-							<d2l-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-filter-dropdown-option>
-						</d2l-filter-dropdown-category>
-					</d2l-filter-dropdown>
-					<d2l-applied-filters for="filter">
-					</d2l-applied-filters>
-					<script>
-						const filter = document.querySelector('#filter');
-						filter.addEventListener('d2l-filter-dropdown-close', (e) => {
-							logEvent(e, 'Filter dropdown closed!');
-						});
-						filter.addEventListener('d2l-filter-dropdown-cleared', (e) => {
-							logEvent(e, 'Filters clear button clicked!');
-						});
-						filter.addEventListener('d2l-filter-dropdown-category-selected', (e) => {
-							logEvent(e, 'Filter category tab selected!');
-						});
-						filter.addEventListener('d2l-filter-dropdown-category-searched', (e) => {
-							logEvent(e, 'Filter category searched!');
-						});
-						filter.addEventListener('d2l-filter-dropdown-category-slotchange', (e) => {
-							logEvent(e, 'Filter category slotchange!');
-						});
-						filter.addEventListener('d2l-filter-dropdown-option-change', (e) => {
-							logEvent(e, 'Filter option clicked!');
-							if (e.detail.selected) {
-								filter.totalSelectedOptionCount++;
-							} else {
-								filter.totalSelectedOptionCount--;
-							}
-						});
-						/* eslint-disable no-console */
-						function logEvent(e, text) {
-							console.group(text);
-							console.log('event', e);
-							if (e.detail) console.log('detail', e.detail);
-							console.groupEnd();
-						}
-						/* eslint-enable no-console */
-					</script>
-				</template>
+				<d2l-applied-filters for="filter"></d2l-applied-filters>
+			</d2l-demo-snippet>
+
+			<h2>d2l-applied-filters with custom label text</h2>
+
+			<d2l-demo-snippet>
+				<d2l-applied-filters for="filter" applied-filter-label-text="Filters selected:">
+				</d2l-applied-filters>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/demo/d2l-filter-dropdown/templated-filter-dropdown-demo.js
+++ b/demo/d2l-filter-dropdown/templated-filter-dropdown-demo.js
@@ -121,7 +121,7 @@ class TemplatedFilterDropdownFilter extends LitElement {
 						key="${f.key}"
 						category-text="${f.title}"
 						selected-option-count="${f.numSelected}">
-						
+
 						${f.options.map(o => html`
 							<d2l-filter-dropdown-option
 								?selected="${o.selected}"

--- a/test/d2l-applied-filters/d2l-applied-filters.html
+++ b/test/d2l-applied-filters/d2l-applied-filters.html
@@ -32,7 +32,7 @@
 							<d2l-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-filter-dropdown-option>
 						</d2l-filter-dropdown-category>
 					</d2l-filter-dropdown>
-					<d2l-applied-filters for="dropdown" applied-filters-label-text="The applied filters"></d2l-applied-filters>
+					<d2l-applied-filters for="dropdown" label-text="The applied filters"></d2l-applied-filters>
 				</div>
 			</template>
 		</test-fixture>
@@ -56,7 +56,7 @@
 				});
 				test('attributes are set correctly', () => {
 					assert.equal(appliedFilters.for, 'dropdown');
-					assert.equal(appliedFilters.appliedFiltersLabelText, 'The applied filters');
+					assert.equal(appliedFilters.labelText, 'The applied filters');
 				});
 				test('instantiates with the selected filters added as multi-select items', () => {
 					const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');

--- a/test/d2l-applied-filters/d2l-applied-filters.html
+++ b/test/d2l-applied-filters/d2l-applied-filters.html
@@ -32,7 +32,7 @@
 							<d2l-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-filter-dropdown-option>
 						</d2l-filter-dropdown-category>
 					</d2l-filter-dropdown>
-					<d2l-applied-filters for="dropdown"></d2l-applied-filters>
+					<d2l-applied-filters for="dropdown" applied-filter-label-text="The applied filters"></d2l-applied-filters>
 				</div>
 			</template>
 		</test-fixture>
@@ -56,6 +56,7 @@
 				});
 				test('attributes are set correctly', () => {
 					assert.equal(appliedFilters.for, 'dropdown');
+					assert.equal(appliedFilters.appliedFilterLabelText, 'The applied filters');
 				});
 				test('instantiates with the selected filters added as multi-select items', () => {
 					const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');

--- a/test/d2l-applied-filters/d2l-applied-filters.html
+++ b/test/d2l-applied-filters/d2l-applied-filters.html
@@ -32,7 +32,7 @@
 							<d2l-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-filter-dropdown-option>
 						</d2l-filter-dropdown-category>
 					</d2l-filter-dropdown>
-					<d2l-applied-filters for="dropdown" applied-filter-label-text="The applied filters"></d2l-applied-filters>
+					<d2l-applied-filters for="dropdown" applied-filters-label-text="The applied filters"></d2l-applied-filters>
 				</div>
 			</template>
 		</test-fixture>
@@ -56,7 +56,7 @@
 				});
 				test('attributes are set correctly', () => {
 					assert.equal(appliedFilters.for, 'dropdown');
-					assert.equal(appliedFilters.appliedFilterLabelText, 'The applied filters');
+					assert.equal(appliedFilters.appliedFiltersLabelText, 'The applied filters');
 				});
 				test('instantiates with the selected filters added as multi-select items', () => {
 					const filters = appliedFilters.shadowRoot.querySelectorAll('d2l-labs-multi-select-list-item');


### PR DESCRIPTION
For insights-engagement-dashboard we want the label to be "Showing only:" instead of "Applied Filters:".

![image](https://user-images.githubusercontent.com/11587338/96502837-5ccb1a80-1220-11eb-86db-b09f10d8885f.png)
