### PR TITLE
fix to use new "d2l-menu-item-text" CSS class

### DIFF
--- a/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
+++ b/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js
@@ -11,7 +11,7 @@ class FilterDropdownOption extends RtlMixin(MenuItemSelectableMixin(LitElement))
 
 	static get styles() {
 		return [menuItemSelectableStyles, css`
-			:host > span {
+			.d2l-menu-item-text {
 				white-space: normal;
 			}
 		`];
@@ -33,7 +33,7 @@ class FilterDropdownOption extends RtlMixin(MenuItemSelectableMixin(LitElement))
 	render() {
 		return html`
 			<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
-			<span>${this.text}</span>
+			<span class="d2l-menu-item-text">${this.text}</span>
 		`;
 	}
 

--- a/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
+++ b/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js
@@ -16,7 +16,7 @@ class SortByDropdownOption extends RtlMixin(MenuItemRadioMixin(LitElement)) {
 	render() {
 		return html`
 			<d2l-icon icon="tier1:check" aria-hidden="true"></d2l-icon>
-			<span>${this.text}</span>
+			<span class="d2l-menu-item-text">${this.text}</span>
 		`;
 	}
 


### PR DESCRIPTION
These were the only places relying on a plain `span` to exist that now needed to apply the text class name.