### PR TITLE
fix: install web-component-analyzer in release only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
       - name: Create custom-elements.json
-        run: npx wca analyze components/**/*.js --format json --outFile custom-elements.json
+        run: |
+          npm install web-component-analyzer@1 --no-save
+          npx wca analyze components/**/*.js --format json --outFile custom-elements.json
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "polymer-cli": "^1",
-    "wct-browser-legacy": "^1",
-    "web-component-analyzer": "^1"
+    "wct-browser-legacy": "^1"
   },
   "version": "4.0.0",
   "dependencies": {


### PR DESCRIPTION
Forgot to `npm i`, but to avoid that in release I'll just install the analyzer there.