### PR TITLE
DE43090 Add translations for the Applied Filters component

### DIFF
--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -13,15 +13,16 @@ import de from './lang/de.js';
 import en from './lang/en.js';
 import es from './lang/es.js';
 import esMx from './lang/es-mx.js';
+import fi from './lang/fi.js';
 import fr from './lang/fr.js';
 import frCa from './lang/fr-ca.js';
 import ja from './lang/ja.js';
 import ko from './lang/ko.js';
+import nb from './lang/nb.js';
 import nl from './lang/nl.js';
 import ptBr from './lang/pt-br.js';
 import sv from './lang/sv.js';
 import tr from './lang/tr.js';
-// import zh from  './lang/zh.js';
 import zhCn from  './lang/zh-cn.js';
 import zhTw from './lang/zh-tw.js';
 /* eslint sort-imports: "warn" */
@@ -110,22 +111,18 @@ class D2lLabsAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			'en': en,
 			'es': es,
 			'es-mx': esMx,
-			'fi': {},
+			'fi': fi,
 			'fr': fr,
 			'fr-ca': frCa,
-			'fr-CA': frCa,
 			'ja': ja,
 			'ko': ko,
-			'nb': {},
+			'nb': nb,
 			'nl': nl,
 			'pt': ptBr,
 			'sv': sv,
 			'tr': tr,
-			'zh': {},
 			'zh-cn': zhCn,
-			'zh-CN': zhCn,
 			'zh-tw': zhTw,
-			'zh-TW': zhTw
 		};
 	}
 

--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -7,6 +7,25 @@ import { getComposedChildren } from '@brightspace-ui/core/helpers/dom';
 import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
+/* eslint sort-imports: "off" */
+import arSa from './lang/ar-sa.js';
+import de from './lang/de.js';
+import en from './lang/en.js';
+import es from './lang/es.js';
+import esMx from './lang/es-mx.js';
+import fr from './lang/fr.js';
+import frCa from './lang/fr-ca.js';
+import ja from './lang/ja.js';
+import ko from './lang/ko.js';
+import nl from './lang/nl.js';
+import ptBr from './lang/pt-br.js';
+import sv from './lang/sv.js';
+import tr from './lang/tr.js';
+// import zh from  './lang/zh.js';
+import zhCn from  './lang/zh-CN.js';
+import zhTw from './lang/zh-TW.js';
+/* eslint sort-imports: "warn" */
+
 const DROPDOWN_NAME = 'D2L-LABS-FILTER-DROPDOWN';
 const DROPDOWN_CATEGORY_NAME = 'D2L-LABS-FILTER-DROPDOWN-CATEGORY';
 const DROPDOWN_OPTION_NAME = 'D2L-LABS-FILTER-DROPDOWN-OPTION';
@@ -86,41 +105,27 @@ class D2lLabsAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 	static get resources() {
 		return {
-			'ar': {
-			},
-			'de': {
-			},
-			'en': {
-				appliedFilters: 'Applied Filters:',
-				noActiveFilters: 'No active filters',
-				filterRemoved: 'Filter {filterText} removed',
-				clearFilters: 'Clear filters',
-				allFiltersRemoved: 'All filters removed'
-			},
-			'es': {
-			},
-			'fi': {
-			},
-			'fr': {
-			},
-			'ja': {
-			},
-			'ko': {
-			},
-			'nb': {
-			},
-			'nl': {
-			},
-			'pt': {
-			},
-			'sv': {
-			},
-			'tr': {
-			},
-			'zh': {
-			},
-			'zh-tw': {
-			}
+			'ar': arSa,
+			'de': de,
+			'en': en,
+			'es': es,
+			'es-mx': esMx,
+			'fi': {},
+			'fr': fr,
+			'fr-ca': frCa,
+			'fr-CA': frCa,
+			'ja': ja,
+			'ko': ko,
+			'nb': {},
+			'nl': nl,
+			'pt': ptBr,
+			'sv': sv,
+			'tr': tr,
+			'zh': {},
+			'zh-cn': zhCn,
+			'zh-CN': zhCn,
+			'zh-tw': zhTw,
+			'zh-TW': zhTw
 		};
 	}
 

--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -1,13 +1,13 @@
+/* eslint sort-imports: ["error", {"allowSeparatedGroups": true}] */
 import '@brightspace-ui-labs/multi-select/multi-select-list';
 import '@brightspace-ui-labs/multi-select/multi-select-list-item';
-import { css, html, LitElement } from 'lit-element';
+import { LitElement, css, html } from 'lit-element';
+import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getComposedChildren } from '@brightspace-ui/core/helpers/dom';
-import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-/* eslint-disable sort-imports */
 import ar from './lang/ar-sa.js';
 import de from './lang/de.js';
 import en from './lang/en.js';
@@ -25,7 +25,6 @@ import sv from './lang/sv.js';
 import tr from './lang/tr.js';
 import zhCn from  './lang/zh-cn.js';
 import zhTw from './lang/zh-tw.js';
-/* eslint-enable sort-imports*/
 
 const DROPDOWN_NAME = 'D2L-LABS-FILTER-DROPDOWN';
 const DROPDOWN_CATEGORY_NAME = 'D2L-LABS-FILTER-DROPDOWN-CATEGORY';

--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -7,8 +7,8 @@ import { getComposedChildren } from '@brightspace-ui/core/helpers/dom';
 import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-/* eslint sort-imports: "off" */
-import arSa from './lang/ar-sa.js';
+/* eslint-disable sort-imports */
+import ar from './lang/ar-sa.js';
 import de from './lang/de.js';
 import en from './lang/en.js';
 import es from './lang/es.js';
@@ -20,12 +20,12 @@ import ja from './lang/ja.js';
 import ko from './lang/ko.js';
 import nb from './lang/nb.js';
 import nl from './lang/nl.js';
-import ptBr from './lang/pt-br.js';
+import pt from './lang/pt-br.js';
 import sv from './lang/sv.js';
 import tr from './lang/tr.js';
 import zhCn from  './lang/zh-cn.js';
 import zhTw from './lang/zh-tw.js';
-/* eslint sort-imports: "warn" */
+/* eslint-enable sort-imports*/
 
 const DROPDOWN_NAME = 'D2L-LABS-FILTER-DROPDOWN';
 const DROPDOWN_CATEGORY_NAME = 'D2L-LABS-FILTER-DROPDOWN-CATEGORY';
@@ -106,7 +106,7 @@ class D2lLabsAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 
 	static get resources() {
 		return {
-			'ar': arSa,
+			'ar': ar,
 			'de': de,
 			'en': en,
 			'es': es,
@@ -118,7 +118,7 @@ class D2lLabsAppliedFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
 			'ko': ko,
 			'nb': nb,
 			'nl': nl,
-			'pt': ptBr,
+			'pt': pt,
 			'sv': sv,
 			'tr': tr,
 			'zh-cn': zhCn,

--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -22,8 +22,8 @@ import ptBr from './lang/pt-br.js';
 import sv from './lang/sv.js';
 import tr from './lang/tr.js';
 // import zh from  './lang/zh.js';
-import zhCn from  './lang/zh-CN.js';
-import zhTw from './lang/zh-TW.js';
+import zhCn from  './lang/zh-cn.js';
+import zhTw from './lang/zh-tw.js';
 /* eslint sort-imports: "warn" */
 
 const DROPDOWN_NAME = 'D2L-LABS-FILTER-DROPDOWN';

--- a/components/applied-filters/lang/ar-sa.js
+++ b/components/applied-filters/lang/ar-sa.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'عوامل التصفية المطبقة:',
+	noActiveFilters: 'لا تتوفر عوامل تصفية نشطة',
+	filterRemoved: 'تمت إزالة عامل التصفية {filterText}',
+	clearFilters: 'مسح عوامل التصفية',
+	allFiltersRemoved: 'تمت إزالة كل عوامل التصفية'
+};

--- a/components/applied-filters/lang/cy.js
+++ b/components/applied-filters/lang/cy.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Hidlyddion a Gymhwyswyd:',
+	noActiveFilters: 'Dim hidlyddion gweithredol',
+	filterRemoved: 'Mae’r Hidlydd {filterText} wedi’i dynnu',
+	clearFilters: 'Clirio hidlyddion',
+	allFiltersRemoved: 'Tynnwyd pob hidlydd',
+};

--- a/components/applied-filters/lang/cy.js
+++ b/components/applied-filters/lang/cy.js
@@ -3,5 +3,5 @@ export default {
 	noActiveFilters: 'Dim hidlyddion gweithredol',
 	filterRemoved: 'Mae’r Hidlydd {filterText} wedi’i dynnu',
 	clearFilters: 'Clirio hidlyddion',
-	allFiltersRemoved: 'Tynnwyd pob hidlydd',
+	allFiltersRemoved: 'Tynnwyd pob hidlydd'
 };

--- a/components/applied-filters/lang/da.js
+++ b/components/applied-filters/lang/da.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Anvendte filtre:',
+	noActiveFilters: 'Ingen aktive filtre',
+	filterRemoved: 'Filteret {filterText} er fjernet',
+	clearFilters: 'Ryd filtre',
+	allFiltersRemoved: 'Alle filtre er fjernet'
+};

--- a/components/applied-filters/lang/de.js
+++ b/components/applied-filters/lang/de.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Angewendete Filter:',
+	noActiveFilters: 'Keine aktiven Filter',
+	filterRemoved: 'Filter {filterText} entfernt',
+	clearFilters: 'Filter löschen',
+	allFiltersRemoved: 'Alle Filter entfernt'
+};

--- a/components/applied-filters/lang/en.js
+++ b/components/applied-filters/lang/en.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Applied Filters:',
+	noActiveFilters: 'No active filters',
+	filterRemoved: 'Filter {filterText} removed',
+	clearFilters: 'Clear filters',
+	allFiltersRemoved: 'All filters removed'
+};

--- a/components/applied-filters/lang/es-mx.js
+++ b/components/applied-filters/lang/es-mx.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Filtros aplicados:',
+	noActiveFilters: 'No hay filtros activos',
+	filterRemoved: 'Filtro {filterText} eliminado',
+	clearFilters: 'Borrar filtros',
+	allFiltersRemoved: 'Todos los filtros eliminados'
+};

--- a/components/applied-filters/lang/es.js
+++ b/components/applied-filters/lang/es.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Filtros aplicados:',
+	noActiveFilters: 'Sin filtros activos',
+	filterRemoved: 'Filtro {filterText} eliminado',
+	clearFilters: 'Borrar filtros',
+	allFiltersRemoved: 'Todos los filtros eliminados'
+};

--- a/components/applied-filters/lang/fi.js
+++ b/components/applied-filters/lang/fi.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Käytetyt suodattimet:',
+	noActiveFilters: 'Ei aktiivisia suodattimia',
+	filterRemoved: 'Suodatin {filterText} poistettu',
+	clearFilters: 'Tyhjennä suodattimet',
+	allFiltersRemoved: 'Kaikki suodattimet poistettu'
+};

--- a/components/applied-filters/lang/fr-ca.js
+++ b/components/applied-filters/lang/fr-ca.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Filtres appliqués:',
+	noActiveFilters: 'Aucun filtre appliqué',
+	filterRemoved: 'Filtre {filterText} retiré',
+	clearFilters: 'Supprimer les filtres',
+	allFiltersRemoved: 'Tous les filtres sont retirés'
+};

--- a/components/applied-filters/lang/fr.js
+++ b/components/applied-filters/lang/fr.js
@@ -1,5 +1,5 @@
 export default {
-	appliedFilters : 'Filtres appliqués :',
+	appliedFilters : 'Filtres appliqués:',
 	noActiveFilters: 'Aucun filtre actif',
 	filterRemoved: 'Filtre {filterText} supprimé',
 	clearFilters: 'Supprimer les filtres',

--- a/components/applied-filters/lang/fr.js
+++ b/components/applied-filters/lang/fr.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters : 'Filtres appliqués :',
+	noActiveFilters: 'Aucun filtre actif',
+	filterRemoved: 'Filtre {filterText} supprimé',
+	clearFilters: 'Supprimer les filtres',
+	allFiltersRemoved: 'Tous les filtre supprimés'
+};

--- a/components/applied-filters/lang/ja.js
+++ b/components/applied-filters/lang/ja.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: '適用されたフィルタ:',
+	noActiveFilters: 'アクティブなフィルタはありません',
+	filterRemoved: 'フィルタ {filterText} を解除しました',
+	clearFilters: 'フィルタのクリア',
+	allFiltersRemoved: 'すべてのフィルタを解除しました'
+};

--- a/components/applied-filters/lang/ko.js
+++ b/components/applied-filters/lang/ko.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: '적용된 필터:',
+	noActiveFilters: '활성 필터 없음',
+	filterRemoved: '필터 {filterText} 제거됨',
+	clearFilters: '필터 지우기',
+	allFiltersRemoved: '모든 필터 제거됨'
+};

--- a/components/applied-filters/lang/nb.js
+++ b/components/applied-filters/lang/nb.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Brukte filtre:',
+	noActiveFilters: 'Ingen aktive filtre',
+	filterRemoved: 'Filter {filterText} fjernet',
+	clearFilters: 'Fjern filtre',
+	allFiltersRemoved: 'Alle filtre fjernet'
+};

--- a/components/applied-filters/lang/nl.js
+++ b/components/applied-filters/lang/nl.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Toegepaste filters:',
+	noActiveFilters: 'Geen actieve filters',
+	filterRemoved: 'Filter {filterText} verwijderd',
+	clearFilters: 'Filters wissen',
+	allFiltersRemoved: 'Alle filters verwijderd'
+};

--- a/components/applied-filters/lang/pt-br.js
+++ b/components/applied-filters/lang/pt-br.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Filtros aplicados:',
+	noActiveFilters: 'Nenhum filtro ativo',
+	filterRemoved: 'Filtro {filterText} removido',
+	clearFilters: 'Limpar filtros',
+	allFiltersRemoved: 'Todos os filtros foram removidos'
+};

--- a/components/applied-filters/lang/sv.js
+++ b/components/applied-filters/lang/sv.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Tillämpade filter:',
+	noActiveFilters: 'Inga aktiva filter',
+	filterRemoved: 'Filtret {filterText} har tagits bort',
+	clearFilters: 'Rensa filter',
+	allFiltersRemoved: 'Alla filter har tagits bort'
+};

--- a/components/applied-filters/lang/tr.js
+++ b/components/applied-filters/lang/tr.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: 'Uygulanan Filtreler:',
+	noActiveFilters: 'Etkin filtre yok',
+	filterRemoved: 'Filtre {filterText} kaldırıldı',
+	clearFilters: 'Filtreleri temizle',
+	allFiltersRemoved: 'Tüm filtreler kaldırıldı'
+};

--- a/components/applied-filters/lang/zh-cn.js
+++ b/components/applied-filters/lang/zh-cn.js
@@ -1,5 +1,5 @@
 export default {
-	appliedFilters: '已应用筛选器：',
+	appliedFilters: '已应用筛选器:',
 	noActiveFilters: '无活动筛选器',
 	filterRemoved: '筛选器 {filterText} 已移除',
 	clearFilters: '清除筛选器',

--- a/components/applied-filters/lang/zh-cn.js
+++ b/components/applied-filters/lang/zh-cn.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: '已应用筛选器：',
+	noActiveFilters: '无活动筛选器',
+	filterRemoved: '筛选器 {filterText} 已移除',
+	clearFilters: '清除筛选器',
+	allFiltersRemoved: '所有筛选器已移除'
+};

--- a/components/applied-filters/lang/zh-tw.js
+++ b/components/applied-filters/lang/zh-tw.js
@@ -1,0 +1,7 @@
+export default {
+	appliedFilters: '套用的篩選條件：',
+	noActiveFilters: '沒有作用中的篩選條件',
+	filterRemoved: '已移除篩選條件 {filterText}',
+	clearFilters: '清除篩選條件',
+	allFiltersRemoved: '已移除所有篩選條件'
+};

--- a/components/applied-filters/lang/zh-tw.js
+++ b/components/applied-filters/lang/zh-tw.js
@@ -1,5 +1,5 @@
 export default {
-	appliedFilters: '套用的篩選條件：',
+	appliedFilters: '套用的篩選條件:',
 	noActiveFilters: '沒有作用中的篩選條件',
 	filterRemoved: '已移除篩選條件 {filterText}',
 	clearFilters: '清除篩選條件',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^7",
     "eslint-config-brightspace": "^0.10",
     "eslint-plugin-html": "^6",
-    "eslint-plugin-lit": "^1",
+    "eslint-plugin-lit": "~1.4.0",
     "eslint-plugin-sort-class-members": "^1",
     "polymer-cli": "^1",
     "wct-browser-legacy": "^1"


### PR DESCRIPTION
## Description
* Added new `.js` files for each language 
## Testing Steps
To test in Portfolio:
1. Open the [folio-app](https://github.com/Brightspace/folio-app) project
2. Either:
    i. From the terminal, run 
```npm install git://github.com/BrightspaceUILabs/facet-filter-sort.git#ec60c9c25feab7f70d97bb20a8ca7bc69e4d7907```
    OR
    ii. Update `package.json` to:
    ```
    "dependencies": {
        "@brightspace-ui-labs/facet-filter-sort": "BrightspaceUILabs/facet-filter-sort#ec60c9c25feab7f70d97bb20a8ca7bc69e4d7907",
    ```
3. Run Portfolio locally
4. Log in as an instructor
5. Change the user's default language so that it's not English
6. Navigate to Portfolio
7. Toggle to the Evidence View
8. Verify that the "Applied Filters" section is translated according to the language selected in step 5
## Rally
https://rally1.rallydev.com/#/378960033600d/dashboard?detail=%2Fdefect%2F518698053064&fdp=true?fdp=true