### PR TITLE
fix: awaiting updateComplete instead of requestUpdate()

### DIFF
--- a/components/filter-dropdown/filter-dropdown-category.js
+++ b/components/filter-dropdown/filter-dropdown-category.js
@@ -155,7 +155,8 @@ class LabsFilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitEl
 		const oldVal = this._categoryText;
 		if (oldVal !== val) {
 			this._categoryText = val;
-			this.requestUpdate().then(() => {
+			this.requestUpdate();
+			this.updateComplete.then(() => {
 				this._updateTabText(this._categoryText, this.selectedOptionCount);
 			});
 		}
@@ -169,7 +170,8 @@ class LabsFilterDropdownCategory extends LocalizeStaticMixin(TabPanelMixin(LitEl
 		const oldVal = this._selectedOptionCount;
 		if (oldVal !== val) {
 			this._selectedOptionCount = val;
-			this.requestUpdate().then(() => {
+			this.requestUpdate();
+			this.updateComplete.then(() => {
 				this._updateTabText(this.categoryText, this._selectedOptionCount);
 			});
 		}

--- a/test/filter-dropdown/filter-dropdown.html
+++ b/test/filter-dropdown/filter-dropdown.html
@@ -92,7 +92,8 @@
 
 					clearButton.click();
 				});
-				test('closing the filter triggers the d2l-labs-filter-dropdown-close event', (done) => {
+				// dependent on a fix to: https://github.com/BrightspaceUI/core/issues/1575
+				test.skip('closing the filter triggers the d2l-labs-filter-dropdown-close event', (done) => {
 					const dropdown = filter.shadowRoot.querySelector('d2l-dropdown-tabs');
 					filter.addEventListener('d2l-labs-filter-dropdown-close', () => {
 						done();

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,17 +10,17 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.15",
+          "platform": "macOS 11.00",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.15",
+          "platform": "macOS 11.00",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.15",
+          "platform": "macOS 11.00",
           "version": ""
         }
       ]


### PR DESCRIPTION
`requestUpdate` [no longer returns a Promise](https://lit.dev/docs/releases/upgrade/#litelement) in Lit 2.0, so instead you're supposed to `await elem.updateComplete`.