### PR TITLE
Try to fix filter test in safari

### DIFF
--- a/test/filter-dropdown/filter-dropdown.html
+++ b/test/filter-dropdown/filter-dropdown.html
@@ -92,17 +92,15 @@
 
 					clearButton.click();
 				});
-				// dependent on a fix to: https://github.com/BrightspaceUI/core/issues/1575
-				test.skip('closing the filter triggers the d2l-labs-filter-dropdown-close event', (done) => {
+				test('closing the filter triggers the d2l-labs-filter-dropdown-close event', (done) => {
 					const dropdown = filter.shadowRoot.querySelector('d2l-dropdown-tabs');
 					filter.addEventListener('d2l-labs-filter-dropdown-close', () => {
 						done();
 					});
 
-					dropdown.toggleOpen();
-
-					requestAnimationFrame(() => {
-						requestAnimationFrame(() => {
+					dropdown.updateComplete.then(() => {
+						dropdown.toggleOpen();
+						dropdown.updateComplete.then(() => {
 							dropdown.toggleOpen();
 						});
 					});


### PR DESCRIPTION
From my testing, this test started failing in filter at the `1.150.1` version of `core`: https://github.com/BrightspaceUI/core/compare/v1.150.0...v1.150.1

However, digging into this, this code is just adjusting the width that's used and doesn't actually cause any more resizes than what was happening before.  From what I can tell, this code somehow changes the timing and that is what is making the test fail.  Removing other unrelated tests in the same file will make the failing test pass.

It _seems_ like Safari's ResizeObserver reporter code gets mad if we try to close the dropdown or end the test before it's done telling us things.  This change seems to make things more stable, but the open issue in `core` may still be valid - it does seem to resize more than neccessary.