### PR TITLE
US134386 - Add new d2l-labs-applied-core-filters component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Install dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Create custom-elements.json
         run: |
           npm install web-component-analyzer@1 --no-save

--- a/README.md
+++ b/README.md
@@ -28,12 +28,59 @@ npm install @brightspace-ui-labs/facet-filter-sort
 
 ## Components
 
-- [d2l-labs-filter-dropdown](#d2l-labs-filter-dropdown)
 - [d2l-labs-search-facets](#d2l-labs-search-facets)
 - [d2l-labs-search-results-count](#d2l-labs-search-results-count)
 - [d2l-labs-sort-by-dropdown](#d2l-labs-sort-by-dropdown)
-- [d2l-labs-applied-filters](#d2l-labs-applied-filters)
 - [d2l-labs-applied-core-filters](#d2l-labs-applied-core-filters)
+
+### d2l-labs-search-facets
+
+<img src="/images/d2l-labs-search-facets.png?raw=true" width="450">
+
+#### Usage
+
+To Do
+
+### d2l-labs-search-results-count
+
+<img src="/images/d2l-labs-search-results-count.png?raw=true" width="450">
+
+#### Usage
+
+To Do
+
+### d2l-labs-sort-by-dropdown
+
+<img src="/images/d2l-labs-sort-by-dropdown.png?raw=true" width="450">
+
+#### Usage
+
+To Do
+
+### d2l-labs-applied-core-filters
+
+The same design as the `d2l-labs-applied-filters` above, but this version works with the `d2l-filter` component in `core`. It supports hooking up to multiple filters and will be migrated to `core` once designs are finalized.
+
+#### Attributes
+
+- `filter-ids`: Ids (space-delimited) of the filter components to subscribe to
+- `label-text` (optional): The text displayed in this component's label. Defaults to "Applied Filters:".
+
+#### Usage
+
+Set the `filter-ids` param to the ids of the `d2l-filter`s that you want to track.
+The `d2l-filter`s must be in the same DOM scope.
+
+```html
+<d2l-filter id="course"> ... </d2l-filter>
+<d2l-filter id="role"> ... </d2l-filter>
+<d2l-labs-applied-core-filters filter-ids="course role"></d2l-labs-applied-core-filters>
+```
+
+## Deprecated Components
+
+- [d2l-labs-filter-dropdown](#d2l-labs-filter-dropdown)
+- [d2l-labs-applied-filters](#d2l-labs-applied-filters)
 
 ### d2l-labs-filter-dropdown
 
@@ -127,33 +174,9 @@ Note that for the header and opener text overrides, if the terms are to reflect 
 - `d2l-labs-filter-dropdown-category-searched`: Fired when a filter category is searched.
 - `d2l-labs-filter-dropdown-option-change`: Fired when a filter option is selected.
 
-### d2l-labs-search-facets
-
-<img src="/images/d2l-labs-search-facets.png?raw=true" width="450">
-
-#### Usage
-
-To Do
-
-### d2l-labs-search-results-count
-
-<img src="/images/d2l-labs-search-results-count.png?raw=true" width="450">
-
-#### Usage
-
-To Do
-
-### d2l-labs-sort-by-dropdown
-
-<img src="/images/d2l-labs-sort-by-dropdown.png?raw=true" width="450">
-
-#### Usage
-
-To Do
-
 ### d2l-labs-applied-filters
 
-A multi-select-list allowing the user to see (and remove) the currently applied filters.  Works with the `d2l-labs-filter-dropdown` above. If you are using `d2l-filter` from `core`, see [d2l-labs-applied-core-filters](#d2l-labs-applied-core-filters) below.
+A multi-select-list allowing the user to see (and remove) the currently applied filters.  Works with the `d2l-labs-filter-dropdown` above. If you are using `d2l-filter` from `core`, see [d2l-labs-applied-core-filters](#d2l-labs-applied-core-filters).
 
 NOTE: This component uses the `slotchange` event and so will not work if you require IE support
 
@@ -172,25 +195,6 @@ This also works if the `d2l-labs-filter-dropdown` is a child in the shadow-dom o
 ```html
 <d2l-labs-applied-filters for="filter"></d2l-labs-applied-filters>
 <d2l-labs-filter-dropdown id="filter"> ... </d2l-labs-filter-dropdown>
-```
-### d2l-labs-applied-core-filters
-
-The same design as the `d2l-labs-applied-filters` above, but this version works with the `d2l-filter` component in `core`. It supports hooking up to multiple filters and will be migrated to `core` once designs are finalized.
-
-#### Attributes
-
-- `filter-ids`: Ids (space-delimited) of the filter components to subscribe to
-- `label-text` (optional): The text displayed in this component's label. Defaults to "Applied Filters:".
-
-#### Usage
-
-Set the `filter-ids` param to the ids of the `d2l-filter`s that you want to track.
-The `d2l-filter`s must be in the same DOM scope.
-
-```html
-<d2l-filter id="course"> ... </d2l-filter>
-<d2l-filter id="role"> ... </d2l-filter>
-<d2l-labs-applied-core-filters filter-ids="course role"></d2l-labs-applied-core-filters>
 ```
 
 ## Developing, Testing and Contributing

--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ npm install @brightspace-ui-labs/facet-filter-sort
 - [d2l-labs-search-results-count](#d2l-labs-search-results-count)
 - [d2l-labs-sort-by-dropdown](#d2l-labs-sort-by-dropdown)
 - [d2l-labs-applied-filters](#d2l-labs-applied-filters)
+- [d2l-labs-applied-core-filters](#d2l-labs-applied-core-filters)
 
 ### d2l-labs-filter-dropdown
+
+**DEPRECATED: Use [`d2l-filter`](https://github.com/BrightspaceUI/core/tree/main/components/filter) in `BrightspaceUI/core`.**
 
 <img src="/images/d2l-labs-filter-dropdown.png?raw=true" width="450">
 
@@ -150,7 +153,7 @@ To Do
 
 ### d2l-labs-applied-filters
 
-A multi-select-list allowing the user to see (and remove) the currently applied filters.
+A multi-select-list allowing the user to see (and remove) the currently applied filters.  Works with the `d2l-labs-filter-dropdown` above. If you are using `d2l-filter` from `core`, see [d2l-labs-applied-core-filters](#d2l-labs-applied-core-filters) below.
 
 NOTE: This component uses the `slotchange` event and so will not work if you require IE support
 
@@ -166,10 +169,28 @@ NOTE: This component uses the `slotchange` event and so will not work if you req
 Set the `for` param to be the id of the `d2l-labs-filter-dropdown` that you want to track.
 This also works if the `d2l-labs-filter-dropdown` is a child in the shadow-dom of the element referenced by the id.
 
-
 ```html
 <d2l-labs-applied-filters for="filter"></d2l-labs-applied-filters>
 <d2l-labs-filter-dropdown id="filter"> ... </d2l-labs-filter-dropdown>
+```
+### d2l-labs-applied-core-filters
+
+The same design as the `d2l-labs-applied-filters` above, but this version works with the `d2l-filter` component in `core`. It supports hooking up to multiple filters and will be migrated to `core` once designs are finalized.
+
+#### Attributes
+
+- `filter-ids`: Ids (space-delimited) of the filter components to subscribe to
+- `label-text` (optional): The text displayed in this component's label. Defaults to "Applied Filters:".
+
+#### Usage
+
+Set the `filter-ids` param to the ids of the `d2l-filter`s that you want to track.
+The `d2l-filter`s must be in the same DOM scope.
+
+```html
+<d2l-filter id="course"> ... </d2l-filter>
+<d2l-filter id="role"> ... </d2l-filter>
+<d2l-labs-applied-core-filters filter-ids="course role"></d2l-labs-applied-core-filters>
 ```
 
 ## Developing, Testing and Contributing

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To Do
 
 ### d2l-labs-applied-core-filters
 
-The same design as the `d2l-labs-applied-filters` above, but this version works with the `d2l-filter` component in `core`. It supports hooking up to multiple filters and will be migrated to `core` once designs are finalized.
+The same design as the deprecated `d2l-labs-applied-filters` below, but this version works with the `d2l-filter` component in `core`. It supports hooking up to multiple filters and will be migrated to `core` once designs are finalized.
 
 #### Attributes
 

--- a/components/applied-filters/applied-core-filters.js
+++ b/components/applied-filters/applied-core-filters.js
@@ -1,0 +1,204 @@
+/* eslint sort-imports: ["error", {"allowSeparatedGroups": true}] */
+import '@brightspace-ui-labs/multi-select/multi-select-list.js';
+import '@brightspace-ui-labs/multi-select/multi-select-list-item.js';
+import { LitElement, css, html } from 'lit-element';
+import { IdSubscriberController } from '@brightspace-ui/core/controllers/subscriber/subscriberControllers.js';
+import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
+
+import ar from './lang/ar-sa.js';
+import de from './lang/de.js';
+import en from './lang/en.js';
+import es from './lang/es.js';
+import esMx from './lang/es-mx.js';
+import fi from './lang/fi.js';
+import fr from './lang/fr.js';
+import frCa from './lang/fr-ca.js';
+import ja from './lang/ja.js';
+import ko from './lang/ko.js';
+import nb from './lang/nb.js';
+import nl from './lang/nl.js';
+import pt from './lang/pt-br.js';
+import sv from './lang/sv.js';
+import tr from './lang/tr.js';
+import zhCn from  './lang/zh-cn.js';
+import zhTw from './lang/zh-tw.js';
+
+const CLEAR_FILTERS_THRESHOLD = 4;
+
+/**
+ * A multi-select-list allowing the user to see (and remove) the currently applied filters, adjusted to work with the new core d2l-filter.
+ */
+class D2lLabsAppliedCoreFilters extends RtlMixin(LocalizeStaticMixin(LitElement)) {
+	static get properties() {
+		return {
+			/**
+			 * Ids (space-delimited) of the filter components to subscribe to
+			 * @type {string}
+			 */
+			filterIds: { type: String, attribute: 'filter-ids' },
+			/**
+			 * Optional: The text displayed in this component's label. Default: "Applied Filters:"
+			 */
+			labelText: { type: String, attribute: 'label-text' }
+		};
+	}
+
+	static get styles() {
+		return [bodyCompactStyles, css`
+			:host {
+				display: block;
+			}
+
+			d2l-labs-multi-select-list {
+				flex: 1;
+			}
+
+			.d2l-labs-applied-filters-wrapper {
+				display: flex;
+			}
+
+			.d2l-labs-applied-filters-label {
+				margin-right: 0.25rem;
+				display: inline-block;
+				padding-top: 0.3rem;
+				font-weight: bold;
+			}
+
+			:host([dir="rtl"]) .d2l-labs-applied-filters-label {
+				margin-right: 0;
+				margin-left: 0.25rem;
+			}
+
+			.d2l-labs-applied-filters-none-label {
+				display: inline-block;
+				padding-top: 0.3rem;
+				font-style: italic;
+				color: var(--d2l-color-corundum);
+			}
+
+			#d2l-clear-filters-button {
+				margin-left: 3px;
+				margin-right: 3px;
+			}
+
+			#d2l-list-holder {
+				flex: 1;
+			}
+
+			:host([hidden]) {
+				display: none;
+			}
+
+			[hidden] {
+				display: none;
+			}
+		`];
+	}
+
+	static get resources() {
+		return {
+			'ar': ar,
+			'de': de,
+			'en': en,
+			'es': es,
+			'es-mx': esMx,
+			'fi': fi,
+			'fr': fr,
+			'fr-ca': frCa,
+			'ja': ja,
+			'ko': ko,
+			'nb': nb,
+			'nl': nl,
+			'pt': pt,
+			'sv': sv,
+			'tr': tr,
+			'zh-cn': zhCn,
+			'zh-tw': zhTw,
+		};
+	}
+
+	constructor() {
+		super();
+		this.labelText = '';
+
+		this._allActiveFilters = new Map();
+		this._filters = new IdSubscriberController(this,
+			{ onUnsubscribe: this._removeLostFilter.bind(this) },
+			{ idPropertyName: 'filterIds' }
+		);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this._filters.hostDisconnected();
+	}
+
+	render() {
+		let numActiveFilters = 0;
+		const allActiveFilters = Array.from(this._allActiveFilters);
+		let filters = html`
+			<d2l-labs-multi-select-list
+				collapsable
+				aria-labelledby="d2l-labs-applied-filters-label">
+				${allActiveFilters.map(filter => filter[1].map((value, index) => { numActiveFilters++; return html`
+					<d2l-labs-multi-select-list-item
+						text="${value.text}"
+						deletable
+						data-filter-id="${filter[0]}"
+						data-index="${index}"
+						@d2l-labs-multi-select-list-item-deleted="${this._multiSelectItemDeleted}">
+					</d2l-labs-multi-select-list-item>
+				`;}))}
+			</d2l-labs-multi-select-list>
+		`;
+		if (numActiveFilters === 0) filters = html`<span class="d2l-labs-applied-filters-none-label d2l-body-compact">${this.localize('noActiveFilters')}</span>`;
+
+		return html`
+			<div class="d2l-labs-applied-filters-wrapper">
+				<span id="d2l-labs-applied-filters-label" class="d2l-labs-applied-filters-label d2l-body-compact">${this.labelText || this.localize('appliedFilters')}</span>
+				<div id="d2l-list-holder">
+					${filters}
+					<d2l-button-subtle id="d2l-clear-filters-button" text="${this.localize('clearFilters')}" ?hidden="${numActiveFilters < CLEAR_FILTERS_THRESHOLD}" @click="${this._clearFiltersClicked}"></d2l-button-subtle>
+				</div>
+			</div>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		this._filters.hostUpdated(changedProperties);
+	}
+
+	updateActiveFilters(filterId, activeFilters) {
+		this._allActiveFilters.set(filterId, activeFilters);
+		this.requestUpdate();
+	}
+
+	_clearFiltersClicked() {
+		this._filters.registries.forEach((filter, index) => {
+			if (index === 0) filter.focus();
+			filter.requestFilterClearAll();
+		});
+	}
+
+	_multiSelectItemDeleted(e) {
+		const filterId = e.target.getAttribute('data-filter-id');
+		const filterValueIndex = e.target.getAttribute('data-index');
+		const filterValue = this._allActiveFilters.get(filterId)[filterValueIndex];
+		const filter = this._filters.registries.find(filter => filter.id === filterId);
+		filter.requestFilterValueClear(filterValue.keyObject);
+
+		announce(this.localize('filterRemoved', 'filterText', e.target.text));
+	}
+
+	_removeLostFilter(filterId) {
+		this._allActiveFilters.delete(filterId);
+		this.requestUpdate();
+	}
+
+}
+
+customElements.define('d2l-labs-applied-core-filters', D2lLabsAppliedCoreFilters);

--- a/demo/applied-filters/applied-core-filters.html
+++ b/demo/applied-filters/applied-core-filters.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '@brightspace-ui/core/components/typography/typography.js';
+			import '@brightspace-ui/core/components/filter/filter.js';
+			import '@brightspace-ui/core/components/filter/filter-dimension-set.js';
+			import '@brightspace-ui/core/components/filter/filter-dimension-set-value.js';
+			import '../../components/applied-filters/applied-core-filters.js';
+		</script>
+		<style>
+			d2l-labs-applied-core-filters { display: block; }
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+
+		<d2l-demo-page page-title="d2l-labs-applied-core-filters">
+
+			<h2>Use these core filters to control the applied filters. The first filter is setup to send the dimension and value to the subscribers. The second filter only sends the value.
+			</h2>
+
+			<d2l-filter id="core-filter">
+				<d2l-filter-dimension-set key="1" text="Dim 1">
+					<d2l-filter-dimension-set-value selected text="Option 1 - 1" key="1" ></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 3" key="3"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 4" key="4"></d2l-filter-dimension-set-value>
+				</d2l-filter-dimension-set>
+				<d2l-filter-dimension-set key="2" text="Dim 2">
+					<d2l-filter-dimension-set-value selected text="Option 2 - 1" key="1"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 2 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 2 - 3" key="3"></d2l-filter-dimension-set-value>
+				</d2l-filter-dimension-set>
+			</d2l-filter>
+
+			<d2l-filter id="core-filter-2">
+				<d2l-filter-dimension-set key="1" text="Dim 1" value-only-active-filter-text>
+					<d2l-filter-dimension-set-value selected text="Option 1 - 1" key="1" ></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 3" key="3"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 1 - 4" key="4"></d2l-filter-dimension-set-value>
+				</d2l-filter-dimension-set>
+				<d2l-filter-dimension-set key="2" text="Dim 2" value-only-active-filter-text>
+					<d2l-filter-dimension-set-value selected text="Option 2 - 1" key="1"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 2 - 2" key="2"></d2l-filter-dimension-set-value>
+					<d2l-filter-dimension-set-value text="Option 2 - 3" key="3"></d2l-filter-dimension-set-value>
+				</d2l-filter-dimension-set>
+			</d2l-filter>
+			<script>
+				const coreFilter = document.querySelector('#core-filter');
+				coreFilter.addEventListener('d2l-filter-dimension-first-open', (e) => {
+					logEvent(e, 'Filter dimension opened!');
+				});
+				coreFilter.addEventListener('d2l-filter-dimension-search', (e) => {
+					logEvent(e, 'Filter dimension searched!');
+				});
+				coreFilter.addEventListener('d2l-filter-change', (e) => {
+					logEvent(e, 'Filter value(s) changed!');
+				});
+				/* eslint-disable no-console */
+				function logEvent(e, text) {
+					console.group(text);
+					console.log('event', e);
+					if (e.detail) console.log('detail', e.detail);
+					console.groupEnd();
+				}
+				/* eslint-enable no-console */
+			</script>
+
+			<h2>Default label and registered to both filters</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-applied-core-filters filter-ids="core-filter core-filter-2"></d2l-labs-applied-core-filters>
+			</d2l-demo-snippet>
+
+			<h2>Custom label and registered to only the first filter</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-applied-core-filters filter-ids="core-filter" label-text="Filters selected:">
+				</d2l-labs-applied-core-filters>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+
+	</body>
+</html>

--- a/demo/applied-filters/applied-core-filters.html
+++ b/demo/applied-filters/applied-core-filters.html
@@ -20,7 +20,7 @@
 
 		<d2l-demo-page page-title="d2l-labs-applied-core-filters">
 
-			<h2>Use these core filters to control the applied filters. The first filter is setup to send the dimension and value to the subscribers. The second filter only sends the value.
+			<h2>Use these core filters to control the applied filters. The first filter is set up to send the dimension and value to the subscribers. The second filter only sends the value.
 			</h2>
 
 			<d2l-filter id="core-filter">


### PR DESCRIPTION
This PR adds a new version of the applied-filters component designed to work with the new `d2l-filter`.  it uses the `IdSubscriberController` to subscribe to updates from multiple filters about their active filter values. The styles, localization and most of the `render` method were copied exactly from the [existing applied-filters component](https://github.com/BrightspaceUILabs/facet-filter-sort/blob/master/components/applied-filters/applied-filters.js). But then most of the other code was able to be deleted because `IdSubscriberController` handles it for us.

https://github.com/BrightspaceUI/core/pull/1934 needs to merge first.

Tests will be added in a separate PR.