### PR TITLE
fix: add extension

### DIFF
--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -4,7 +4,7 @@ import '@brightspace-ui-labs/multi-select/multi-select-list-item.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { getComposedChildren } from '@brightspace-ui/core/helpers/dom';
+import { getComposedChildren } from '@brightspace-ui/core/helpers/dom.js';
 import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 


### PR DESCRIPTION
Caused issues downstream for [Brightspace/folio-app](https://github.com/Brightspace/folio-app). Seemed to be the only `.js` extension missing. Resulting error
```
Module not found: Error: Can't resolve '@brightspace-ui/core/helpers/dom' in '/home/runner/work/folio-app/folio-app/node_modules/@brightspace-ui-labs/facet-filter-sort/components/applied-filters'
Did you mean 'dom.js'?
BREAKING CHANGE: The request '@brightspace-ui/core/helpers/dom' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```