### PR TITLE
Lit 2 Upgrade: backwards-compatible changes

### DIFF
--- a/components/applied-filters/applied-core-filters.js
+++ b/components/applied-filters/applied-core-filters.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui-labs/multi-select/multi-select-list.js';
 import '@brightspace-ui-labs/multi-select/multi-select-list-item.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { IdSubscriberController } from '@brightspace-ui/core/controllers/subscriber/subscriberControllers.js';

--- a/components/applied-filters/applied-filters.js
+++ b/components/applied-filters/applied-filters.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui-labs/multi-select/multi-select-list.js';
 import '@brightspace-ui-labs/multi-select/multi-select-list-item.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { getComposedChildren } from '@brightspace-ui/core/helpers/dom.js';

--- a/components/filter-dropdown/filter-dropdown-category.js
+++ b/components/filter-dropdown/filter-dropdown-category.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 import '@brightspace-ui/core/components/menu/menu.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { LocalizeStaticMixin } from '@brightspace-ui/core/mixins/localize-static-mixin.js';
 import { TabPanelMixin } from '@brightspace-ui/core/components/tabs/tab-panel-mixin.js';

--- a/components/filter-dropdown/filter-dropdown-option.js
+++ b/components/filter-dropdown/filter-dropdown-option.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/icons/icon.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element';
 import { MenuItemSelectableMixin } from '@brightspace-ui/core/components/menu/menu-item-selectable-mixin.js';
 import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';

--- a/components/filter-dropdown/filter-dropdown.js
+++ b/components/filter-dropdown/filter-dropdown.js
@@ -153,7 +153,7 @@ class D2LLabsFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.LabsFil
 	}
 
 	close() {
-		this.shadowRoot.querySelector('d2l-dropdown-tabs').close();
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-dropdown-tabs').close();
 	}
 
 	detached() {
@@ -162,7 +162,7 @@ class D2LLabsFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.LabsFil
 	}
 
 	focus() {
-		this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
+		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
 	}
 
 	_getFooterSlotValue(hasFooter) {

--- a/components/filter-dropdown/filter-dropdown.js
+++ b/components/filter-dropdown/filter-dropdown.js
@@ -153,7 +153,7 @@ class D2LLabsFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.LabsFil
 	}
 
 	close() {
-		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-dropdown-tabs').close();
+		this.shadowRoot.querySelector('d2l-dropdown-tabs').close();
 	}
 
 	detached() {
@@ -162,7 +162,7 @@ class D2LLabsFilterDropdown extends mixinBehaviors([D2L.PolymerBehaviors.LabsFil
 	}
 
 	focus() {
-		if (this.shadowRoot) this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
+		this.shadowRoot.querySelector('d2l-dropdown-button-subtle').focus();
 	}
 
 	_getFooterSlotValue(hasFooter) {

--- a/components/sort-by-dropdown/sort-by-dropdown-option.js
+++ b/components/sort-by-dropdown/sort-by-dropdown-option.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/core/components/icons/icon.js';
-import { html, LitElement } from 'lit-element/lit-element.js';
+import { html, LitElement } from 'lit-element';
 import { MenuItemRadioMixin } from '@brightspace-ui/core/components/menu/menu-item-radio-mixin.js';
 import { menuItemSelectableStyles } from '@brightspace-ui/core/components/menu/menu-item-selectable-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';

--- a/demo/filter-dropdown/filter-dropdown.html
+++ b/demo/filter-dropdown/filter-dropdown.html
@@ -22,77 +22,73 @@
 			<h2>d2l-labs-filter-dropdown with dom-repeat data and event hookups</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-templated-filter-dropdown-demo></d2l-labs-templated-filter-dropdown-demo>
-				</template>
+				<d2l-labs-templated-filter-dropdown-demo></d2l-labs-templated-filter-dropdown-demo>
 			</d2l-demo-snippet>
 
 			<h2>Basic d2l-labs-filter-dropdown with hardcoded data and events console logged</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-filter-dropdown id="filter" total-selected-option-count="4">
-						<d2l-labs-filter-dropdown-category key="1" category-text="Category 1">
-							<d2l-labs-filter-dropdown-option selected text="Option 1 - 1 test test test test test test test test test test test test test test test test test test" value="1"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option selected text="Option 1 - 3" value="3"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option selected text="Option 1 - 4" value="4"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 1 - 5" value="5"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 1 - 6" value="6"></d2l-labs-filter-dropdown-option>
-						</d2l-labs-filter-dropdown-category>
-						<d2l-labs-filter-dropdown-category key="2" category-text="Category 2">
-							<d2l-labs-filter-dropdown-option selected text="Option 2 - 1" value="1"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 2 - 2" value="2"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-labs-filter-dropdown-option>
-						</d2l-labs-filter-dropdown-category>
-						<d2l-labs-filter-dropdown-category key="3" category-text="Category 3">
-							<d2l-labs-filter-dropdown-option text="Option 3 - 1" value="1"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 3 - 2" value="2"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 3 - 3" value="3"></d2l-labs-filter-dropdown-option>
-						</d2l-labs-filter-dropdown-category>
-						<d2l-labs-filter-dropdown-category key="4" category-text="Category 4">
-							<d2l-labs-filter-dropdown-option text="Option 4 - 1" value="1"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 4 - 2" value="2"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 4 - 3" value="3"></d2l-labs-filter-dropdown-option>
-						</d2l-labs-filter-dropdown-category>
-						<d2l-labs-filter-dropdown-category key="5" category-text="Category 5" disable-search>
-							<d2l-labs-filter-dropdown-option text="Option 5 - 1" value="1"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 5 - 2" value="2"></d2l-labs-filter-dropdown-option>
-							<d2l-labs-filter-dropdown-option text="Option 5 - 3" value="3"></d2l-labs-filter-dropdown-option>
-						</d2l-labs-filter-dropdown-category>
-					</d2l-labs-filter-dropdown>
-					<script>
-						const filter = document.querySelector('#filter');
-						filter.addEventListener('d2l-labs-filter-dropdown-close', (e) => {
-							logEvent(e, 'Filter dropdown closed!');
-						});
-						filter.addEventListener('d2l-labs-filter-dropdown-cleared', (e) => {
-							logEvent(e, 'Filters clear button clicked!');
-						});
-						filter.addEventListener('d2l-labs-filter-dropdown-category-selected', (e) => {
-							logEvent(e, 'Filter category tab selected!');
-						});
-						filter.addEventListener('d2l-labs-filter-dropdown-category-searched', (e) => {
-							logEvent(e, 'Filter category searched!');
-						});
-						filter.addEventListener('d2l-labs-filter-dropdown-option-change', (e) => {
-							logEvent(e, 'Filter option clicked!');
-							if (e.detail.selected) {
-								filter.totalSelectedOptionCount++;
-							} else {
-								filter.totalSelectedOptionCount--;
-							}
-						});
-						/* eslint-disable no-console */
-						function logEvent(e, text) {
-							console.group(text);
-							console.log('event', e);
-							if (e.detail) console.log('detail', e.detail);
-							console.groupEnd();
+				<d2l-labs-filter-dropdown id="filter" total-selected-option-count="4">
+					<d2l-labs-filter-dropdown-category key="1" category-text="Category 1">
+						<d2l-labs-filter-dropdown-option selected text="Option 1 - 1 test test test test test test test test test test test test test test test test test test" value="1"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 1 - 2" value="2"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option selected text="Option 1 - 3" value="3"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option selected text="Option 1 - 4" value="4"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 1 - 5" value="5"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 1 - 6" value="6"></d2l-labs-filter-dropdown-option>
+					</d2l-labs-filter-dropdown-category>
+					<d2l-labs-filter-dropdown-category key="2" category-text="Category 2">
+						<d2l-labs-filter-dropdown-option selected text="Option 2 - 1" value="1"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 2 - 2" value="2"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 2 - 3" value="3"></d2l-labs-filter-dropdown-option>
+					</d2l-labs-filter-dropdown-category>
+					<d2l-labs-filter-dropdown-category key="3" category-text="Category 3">
+						<d2l-labs-filter-dropdown-option text="Option 3 - 1" value="1"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 3 - 2" value="2"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 3 - 3" value="3"></d2l-labs-filter-dropdown-option>
+					</d2l-labs-filter-dropdown-category>
+					<d2l-labs-filter-dropdown-category key="4" category-text="Category 4">
+						<d2l-labs-filter-dropdown-option text="Option 4 - 1" value="1"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 4 - 2" value="2"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 4 - 3" value="3"></d2l-labs-filter-dropdown-option>
+					</d2l-labs-filter-dropdown-category>
+					<d2l-labs-filter-dropdown-category key="5" category-text="Category 5" disable-search>
+						<d2l-labs-filter-dropdown-option text="Option 5 - 1" value="1"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 5 - 2" value="2"></d2l-labs-filter-dropdown-option>
+						<d2l-labs-filter-dropdown-option text="Option 5 - 3" value="3"></d2l-labs-filter-dropdown-option>
+					</d2l-labs-filter-dropdown-category>
+				</d2l-labs-filter-dropdown>
+				<script>
+					const filter = document.querySelector('#filter');
+					filter.addEventListener('d2l-labs-filter-dropdown-close', (e) => {
+						logEvent(e, 'Filter dropdown closed!');
+					});
+					filter.addEventListener('d2l-labs-filter-dropdown-cleared', (e) => {
+						logEvent(e, 'Filters clear button clicked!');
+					});
+					filter.addEventListener('d2l-labs-filter-dropdown-category-selected', (e) => {
+						logEvent(e, 'Filter category tab selected!');
+					});
+					filter.addEventListener('d2l-labs-filter-dropdown-category-searched', (e) => {
+						logEvent(e, 'Filter category searched!');
+					});
+					filter.addEventListener('d2l-labs-filter-dropdown-option-change', (e) => {
+						logEvent(e, 'Filter option clicked!');
+						if (e.detail.selected) {
+							filter.totalSelectedOptionCount++;
+						} else {
+							filter.totalSelectedOptionCount--;
 						}
-						/* eslint-enable no-console */
-					</script>
-				</template>
+					});
+					/* eslint-disable no-console */
+					function logEvent(e, text) {
+						console.group(text);
+						console.log('event', e);
+						if (e.detail) console.log('detail', e.detail);
+						console.groupEnd();
+					}
+					/* eslint-enable no-console */
+				</script>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,16 +14,16 @@
 
 			Demos
 			<ul>
-				<li><a href="demo/applied-filters/applied-core-filters.html">d2l-labs-applied-core-filters</a></li>
-				<li><a href="demo/search-facets/search-facets.html">d2l-labs-search-facets</a></li>
-				<li><a href="demo/search-results-count/search-results-count.html">d2l-labs-search-results-count</a></li>
-				<li><a href="demo/sort-by-dropdown/sort-by-dropdown.html">d2l-labs-sort-by-dropdown</a></li>
+				<li><a href="applied-filters/applied-core-filters.html">d2l-labs-applied-core-filters</a></li>
+				<li><a href="search-facets/search-facets.html">d2l-labs-search-facets</a></li>
+				<li><a href="search-results-count/search-results-count.html">d2l-labs-search-results-count</a></li>
+				<li><a href="sort-by-dropdown/sort-by-dropdown.html">d2l-labs-sort-by-dropdown</a></li>
 			</ul>
 
 			Deprecated Components
 			<ul>
-				<li><a href="demo/applied-filters/applied-filters.html">d2l-labs-applied-filters</a></li>
-				<li><a href="demo/filter-dropdown/filter-dropdown.html">d2l-labs-filter-dropdown</a></li>
+				<li><a href="applied-filters/applied-filters.html">d2l-labs-applied-filters</a></li>
+				<li><a href="filter-dropdown/filter-dropdown.html">d2l-labs-filter-dropdown</a></li>
 			</ul>
 
 		</d2l-demo-page>

--- a/demo/search-facets/search-facets.html
+++ b/demo/search-facets/search-facets.html
@@ -19,56 +19,52 @@
 			<h2>d2l-labs-search-facets</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-search-facets>
-						<d2l-labs-search-facets-grouping id="status" value="status" text="My Status" has-more="">
-							<d2l-labs-search-facets-option value="new-courses" text="New Courses Only" count="21"></d2l-labs-search-facets-option>
-							<d2l-labs-search-facets-option value="my-list" text="On My List" count="1"></d2l-labs-search-facets-option>
-						</d2l-labs-search-facets-grouping>
-						<d2l-labs-search-facets-grouping id="format" value="format" text="Format" has-more="">
-							<d2l-labs-search-facets-option value="online" text="Online" count="1"></d2l-labs-search-facets-option>
-							<d2l-labs-search-facets-option value="in-class" text="In-Class" count="2"></d2l-labs-search-facets-option>
-						</d2l-labs-search-facets-grouping>
-						<d2l-labs-search-facets-grouping value="location" text="Location">
-							<d2l-labs-search-facets-option value="outside" text="Outside"></d2l-labs-search-facets-option>
-							<d2l-labs-search-facets-option value="inside" text="Inside"></d2l-labs-search-facets-option>
-						</d2l-labs-search-facets-grouping>
-					</d2l-labs-search-facets>
-					<script>
-						document.getElementById('status').addEventListener('d2l-labs-search-facets-grouping-has-more', (e) => {
-							const options = [
-								{ text: 'In Progress', value: 'in-progress', count: '1' },
-								{ text: 'Completed', value: 'completed', count: '10000' }
-							];
-							addOptions(options, e.target);
+				<d2l-labs-search-facets>
+					<d2l-labs-search-facets-grouping id="status" value="status" text="My Status" has-more="">
+						<d2l-labs-search-facets-option value="new-courses" text="New Courses Only" count="21"></d2l-labs-search-facets-option>
+						<d2l-labs-search-facets-option value="my-list" text="On My List" count="1"></d2l-labs-search-facets-option>
+					</d2l-labs-search-facets-grouping>
+					<d2l-labs-search-facets-grouping id="format" value="format" text="Format" has-more="">
+						<d2l-labs-search-facets-option value="online" text="Online" count="1"></d2l-labs-search-facets-option>
+						<d2l-labs-search-facets-option value="in-class" text="In-Class" count="2"></d2l-labs-search-facets-option>
+					</d2l-labs-search-facets-grouping>
+					<d2l-labs-search-facets-grouping value="location" text="Location">
+						<d2l-labs-search-facets-option value="outside" text="Outside"></d2l-labs-search-facets-option>
+						<d2l-labs-search-facets-option value="inside" text="Inside"></d2l-labs-search-facets-option>
+					</d2l-labs-search-facets-grouping>
+				</d2l-labs-search-facets>
+				<script>
+					document.getElementById('status').addEventListener('d2l-labs-search-facets-grouping-has-more', (e) => {
+						const options = [
+							{ text: 'In Progress', value: 'in-progress', count: '1' },
+							{ text: 'Completed', value: 'completed', count: '10000' }
+						];
+						addOptions(options, e.target);
+					});
+					document.getElementById('format').addEventListener('d2l-labs-search-facets-grouping-has-more', (e) => {
+						const options = [
+							{ text: 'Interactive', value: 'interactive', count: '12' },
+							{ text: 'Video Only', value: 'video-only', count: '30' }
+						];
+						addOptions(options, e.target);
+					});
+					function addOptions(options, target) {
+						options.forEach((option) => {
+							const element = document.createElement('d2l-labs-search-facets-option');
+							element.setAttribute('text', option.text);
+							element.setAttribute('value', option.value);
+							element.setAttribute('count', option.count);
+							target.appendChild(element);
 						});
-						document.getElementById('format').addEventListener('d2l-labs-search-facets-grouping-has-more', (e) => {
-							const options = [
-								{ text: 'Interactive', value: 'interactive', count: '12' },
-								{ text: 'Video Only', value: 'video-only', count: '30' }
-							];
-							addOptions(options, e.target);
-						});
-						function addOptions(options, target) {
-							options.forEach((option) => {
-								const element = document.createElement('d2l-labs-search-facets-option');
-								element.setAttribute('text', option.text);
-								element.setAttribute('value', option.value);
-								element.setAttribute('count', option.count);
-								target.appendChild(element);
-							});
-							target.removeAttribute('has-more');
-						}
-					</script>
-				</template>
+						target.removeAttribute('has-more');
+					}
+				</script>
 			</d2l-demo-snippet>
 
 			<h2>d2l-labs-search-facets (templated)</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-templated-search-facets-demo></d2l-labs-templated-search-facets-demo>
-				</template>
+				<d2l-labs-templated-search-facets-demo></d2l-labs-templated-search-facets-demo>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/demo/search-results-count/search-results-count.html
+++ b/demo/search-results-count/search-results-count.html
@@ -16,37 +16,29 @@
 			<h2>d2l-labs-search-results-count</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-search-results-count total-count="22" query="Financial Planning">
-					</d2l-labs-search-results-count>
-				</template>
+				<d2l-labs-search-results-count total-count="22" query="Financial Planning">
+				</d2l-labs-search-results-count>
 			</d2l-demo-snippet>
 
 			<h2>d2l-labs-search-results-count (no query)</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-search-results-count total-count="22">
-					</d2l-labs-search-results-count>
-				</template>
+				<d2l-labs-search-results-count total-count="22">
+				</d2l-labs-search-results-count>
 			</d2l-demo-snippet>
 
 			<h2>d2l-labs-search-results-count (paged)</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-search-results-count range-start="1" range-end="20" total-count="22" query="Financial Planning">
-					</d2l-labs-search-results-count>
-				</template>
+				<d2l-labs-search-results-count range-start="1" range-end="20" total-count="22" query="Financial Planning">
+				</d2l-labs-search-results-count>
 			</d2l-demo-snippet>
 
 			<h2>d2l-labs-search-results-count (paged, no query)</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-search-results-count range-start="1" range-end="20" total-count="22">
-					</d2l-labs-search-results-count>
-				</template>
+				<d2l-labs-search-results-count range-start="1" range-end="20" total-count="22">
+				</d2l-labs-search-results-count>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/demo/sort-by-dropdown/sort-by-dropdown.html
+++ b/demo/sort-by-dropdown/sort-by-dropdown.html
@@ -20,31 +20,27 @@
 			<h2>d2l-labs-sort-by-dropdown</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-sort-by-dropdown label="Sort by options" align="end">
-						<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="newest" text="Newest"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="oldest" text="Oldest"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="name" text="Name"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="high-to-low" text="Price: High to Low"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="low-to-high" text="Price: Low to High"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="long-text" text="A sorting option with longer text"></d2l-labs-sort-by-dropdown-option>
-					</d2l-labs-sort-by-dropdown>
-					<div style="clear: both;"></div>
-				</template>
+				<d2l-labs-sort-by-dropdown label="Sort by options" align="end">
+					<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="newest" text="Newest"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="oldest" text="Oldest"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="name" text="Name"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="high-to-low" text="Price: High to Low"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="low-to-high" text="Price: Low to High"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="long-text" text="A sorting option with longer text"></d2l-labs-sort-by-dropdown-option>
+				</d2l-labs-sort-by-dropdown>
+				<div style="clear: both;"></div>
 			</d2l-demo-snippet>
 
 			<h2>d2l-labs-sort-by-dropdown (compact)</h2>
 
 			<d2l-demo-snippet>
-				<template>
-					<d2l-labs-sort-by-dropdown align="end" label="Compact sort by dropdown" compact="">
-						<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
-						<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
-					</d2l-labs-sort-by-dropdown>
-					<div style="clear: both;"></div>
-				</template>
+				<d2l-labs-sort-by-dropdown align="end" label="Compact sort by dropdown" compact="">
+					<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
+				</d2l-labs-sort-by-dropdown>
+				<div style="clear: both;"></div>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@brightspace-ui-labs/multi-select": "^5",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "lit-element": "^2",
+    "lit-html": "^1",
     "@polymer/polymer": "^3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:lit": "lit-analyzer \"{components, test, demo}/**/*.js\" --strict --rules.no-unknown-tag-name off",
     "lint:polymer": "polymer lint -i \"test/**/*.js\" \"demo/**/*.js\" \"components/**/*.js\"",
     "lint:style": "stylelint \"**/*.{js,html}\"",
-    "start": "web-dev-server --node-resolve --watch --open",
+    "start": "web-dev-server --node-resolve --watch --open --app-index demo/index.html",
     "test": "npm run lint && npm run test:headless",
     "test:headless": "web-test-runner --group default",
     "test:headless:watch": "web-test-runner --group default --watch"
@@ -42,7 +42,7 @@
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
     "polymer-cli": "^1",
-    "sinon": "^12",
+    "sinon": "^13",
     "stylelint": "^14"
   },
   "version": "4.2.3",


### PR DESCRIPTION
This PR makes backwards-compatible changes to prepare this repo for a Lit 2 upgrade. Since the changes are backwards compatible, it can be merged right away.

Non-breaking change checklist:
- [x] Add missing `.js` extensions for lit-html or lit-element imports
- [x] `await requestUpdate` -> `await elem.updateComplete`
- [x] add non-null checks to shadowRoot accesses (not including test files)
  - Only usage is in a Polymer component
- [x] audit usages of `unsafeHTML` to ensure `null`, `undefined` inputs are handled as expected
- [x] remove dynamic code from inside  `<template>` tags (Lit files only)
- [x] remove any dependencies on old Lit versions
- [x] audit `ifDefined` usages for null parameters
  - Usage audited, new behavior makes things better!

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.