### PR TITLE
DO NOT MERGE: Breaking changes for Lit 2

### DIFF
--- a/components/applied-filters/applied-core-filters.js
+++ b/components/applied-filters/applied-core-filters.js
@@ -132,11 +132,6 @@ class D2lLabsAppliedCoreFilters extends RtlMixin(LocalizeStaticMixin(LitElement)
 		};
 	}
 
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this._filters.hostDisconnected();
-	}
-
 	render() {
 		let numActiveFilters = 0;
 		const allActiveFilters = Array.from(this._allActiveFilters);
@@ -166,11 +161,6 @@ class D2lLabsAppliedCoreFilters extends RtlMixin(LocalizeStaticMixin(LitElement)
 				</div>
 			</div>
 		`;
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-		this._filters.hostUpdated(changedProperties);
 	}
 
 	updateActiveFilters(filterId, activeFilters) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -47,12 +47,12 @@
   },
   "version": "4.2.3",
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
-    "@brightspace-ui-labs/multi-select": "^5",
-    "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "lit-element": "^2",
-    "lit-html": "^1",
+    "@brightspace-ui-labs/multi-select": "^6",
+    "d2l-typography": "BrightspaceUI/typography#semver:^8",
+    "lit-element": "^3",
+    "lit-html": "^2",
     "@polymer/polymer": "^3"
   }
 }


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: https://github.com/BrightspaceUILabs/facet-filter-sort/pull/100

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [ ] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.