### PR TITLE
Rename .github/workflows/CODEOWNERS to .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@BrightspaceUILabs/gaudi-dev

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@BrightspaceUILabs/gaudi-dev


### PR DESCRIPTION
This doesn't seem to be working and putting us on PRs.  Does it maybe need to live here instead?