### PR TITLE
add filter option for sort-by-dropdown

### DIFF
--- a/components/sort-by-dropdown/sort-by-dropdown.js
+++ b/components/sort-by-dropdown/sort-by-dropdown.js
@@ -45,8 +45,8 @@ class LabsSortByDropdown extends mixinBehaviors(
 				value: '',
 				observer: function(selection) {
 					this._selectedOptionText = this.compact
-						? this.localize('sort')
-						: this.localize('sortWithOption', 'option', selection);
+						? this.isFilter ? this.localize('filter') : this.localize('sort')
+						: this.isFilter ? this.localize('filterWithOption', 'option', selection) : this.localize('sortWithOption', 'option', selection);
 				}
 			},
 
@@ -85,6 +85,14 @@ class LabsSortByDropdown extends mixinBehaviors(
 			value: {
 				type: String,
 				reflectToAttribute: true
+			},
+			/**
+			 * Indicates whether the selector text displays Sort or Filter
+			 */
+			isFilter: {
+				type: Boolean,
+				value: false,
+				attribute:'is-filter'
 			}
 		};
 	}

--- a/demo/sort-by-dropdown/sort-by-dropdown.html
+++ b/demo/sort-by-dropdown/sort-by-dropdown.html
@@ -43,6 +43,32 @@
 				<div style="clear: both;"></div>
 			</d2l-demo-snippet>
 
+			<h2>d2l-labs-sort-by-dropdown (is-filter)</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-sort-by-dropdown label="Sort by options" align="end" is-filter=true>
+					<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="newest" text="Newest"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="oldest" text="Oldest"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="name" text="Name"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="high-to-low" text="Price: High to Low"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="low-to-high" text="Price: Low to High"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="long-text" text="A sorting option with longer text"></d2l-labs-sort-by-dropdown-option>
+				</d2l-labs-sort-by-dropdown>
+				<div style="clear: both;"></div>
+			</d2l-demo-snippet>
+
+			<h2>d2l-labs-sort-by-dropdown (compact and is-filter)</h2>
+
+			<d2l-demo-snippet>
+				<d2l-labs-sort-by-dropdown align="end" label="Compact sort by dropdown" compact="" is-filter=true>
+					<d2l-labs-sort-by-dropdown-option value="date" text="Date"></d2l-labs-sort-by-dropdown-option>
+					<d2l-labs-sort-by-dropdown-option value="time" text="Time"></d2l-labs-sort-by-dropdown-option>
+				</d2l-labs-sort-by-dropdown>
+				<div style="clear: both;"></div>
+			</d2l-demo-snippet>
+
 		</d2l-demo-page>
 
 		<script>

--- a/lang/en.js
+++ b/lang/en.js
@@ -13,6 +13,7 @@ export default {
 	"filterBy": "Filter By",
 	"filterMultiple": "Filter: {numOptions} Filters",
 	"filterSingle": "Filter: 1 Filter",
+	"filterWithOption": "Filter: {option}",
 	"more": "More",
 	"searchPagedResults": "{rangeStart} - {rangeEnd} of {totalCount} results",
 	"searchPagedResultsForQuery": "{rangeStart} - {rangeEnd} of {totalCount} results for \"{query}\"",


### PR DESCRIPTION
https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F636678076593

Will be used in https://github.com/Brightspace/consistent-evaluation/pull/1114

- Added an attribute (`?is-filter`) to determine whether to display `Filter:` or `Sort:` when using the `d2l-labs-sort-by-dropdown`.

Consistent-evaluation (quizzing) needs a filter-dropdown component where only one selection can be made. The exact functionality of `d2l-labs-sort-by-dropdown`.  I considered making the text editable, but being it is in `facet-filter-sort`, I just left it with those two options.

![question-filtering](https://user-images.githubusercontent.com/32204301/178799083-b7511244-11fd-4b9d-8ac5-191120b2d4d1.gif)

