### PR TITLE
Update `_text` when selected option text changes

### DIFF
--- a/components/sort-by-dropdown/sort-by-dropdown-option.js
+++ b/components/sort-by-dropdown/sort-by-dropdown-option.js
@@ -20,6 +20,16 @@ class LabsSortByDropdownOption extends RtlMixin(MenuItemRadioMixin(LitElement)) 
 		`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('text') && this.selected) {
+			this.dispatchEvent(new CustomEvent('d2l-labs-sort-by-dropdown-option-selected-text-change', {
+				detail: { text: this.text },
+				bubbles: true }
+			));
+		}
+	}
+
 }
 
 customElements.define('d2l-labs-sort-by-dropdown-option', LabsSortByDropdownOption);

--- a/components/sort-by-dropdown/sort-by-dropdown-option.js
+++ b/components/sort-by-dropdown/sort-by-dropdown-option.js
@@ -25,8 +25,8 @@ class LabsSortByDropdownOption extends RtlMixin(MenuItemRadioMixin(LitElement)) 
 		if (changedProperties.has('text') && this.selected) {
 			this.dispatchEvent(new CustomEvent('d2l-labs-sort-by-dropdown-option-selected-text-change', {
 				detail: { text: this.text },
-				bubbles: true }
-			));
+				bubbles: true
+			}));
 		}
 	}
 

--- a/components/sort-by-dropdown/sort-by-dropdown.js
+++ b/components/sort-by-dropdown/sort-by-dropdown.js
@@ -131,12 +131,17 @@ class LabsSortByDropdown extends mixinBehaviors(
 			this._text = initialOption.text;
 			this.value = initialOption.value;
 		});
+
+		this._selectedTextChangeHandler = e => this._text = e.detail.text;
+		this.addEventListener('d2l-labs-sort-by-dropdown-option-selected-text-change', this._selectedTextChangeHandler);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.$['d2l-labs-sort-by-menu'].removeEventListener('d2l-menu-item-change',
-			this._boundListeners._onItemSelect);
+			this._boundListeners._onItemSelect
+		);
+		this.removeEventListener('d2l-labs-sort-by-dropdown-option-selected-text-change', this._selectedTextChangeHandler);
 	}
 
 	_computeSelectedOptionText(selection, localize, resources) {

--- a/test/sort-by-dropdown/sort-by-dropdown.test.js
+++ b/test/sort-by-dropdown/sort-by-dropdown.test.js
@@ -37,6 +37,8 @@ describe('d2l-labs-sort-by-dropdown', () => {
 			await oneEvent(basicFixture, 'd2l-labs-sort-by-dropdown-change');
 			expect(basicFixture.getAttribute('value')).to.equal(option2.value);
 
+			await oneEvent(basicFixture, 'd2l-dropdown-close');
+
 			await clickElem(basicFixture);
 			clickElem(option1);
 			await oneEvent(basicFixture, 'd2l-labs-sort-by-dropdown-change');

--- a/test/sort-by-dropdown/sort-by-dropdown.test.js
+++ b/test/sort-by-dropdown/sort-by-dropdown.test.js
@@ -31,6 +31,16 @@ describe('d2l-labs-sort-by-dropdown', () => {
 			expect(basicFixture._selectedOptionText).to.equal('Sort: Option 1');
 		});
 
+		it('should update the displayed text when the selected option text changes', async() => {
+			await clickElem(basicFixture);
+			expect(basicFixture._text).to.equal(option1.text);
+
+			const newText = 'New Text';
+			option1.text = newText;
+			await oneEvent(basicFixture, 'd2l-labs-sort-by-dropdown-option-selected-text-change');
+			expect(basicFixture._text).to.equal(newText);
+		});
+
 		it('should change to the selected option', async() => {
 			await clickElem(basicFixture);
 			clickElem(option2);

--- a/test/sort-by-dropdown/sort-by-dropdown.test.js
+++ b/test/sort-by-dropdown/sort-by-dropdown.test.js
@@ -32,10 +32,8 @@ describe('d2l-labs-sort-by-dropdown', () => {
 		});
 
 		it('should update the displayed text when the selected option text changes', async() => {
-			await clickElem(basicFixture);
-			expect(basicFixture._text).to.equal(option1.text);
-
 			const newText = 'New Text';
+			expect(basicFixture._text).to.equal(option1.text);
 			option1.text = newText;
 			await oneEvent(basicFixture, 'd2l-labs-sort-by-dropdown-option-selected-text-change');
 			expect(basicFixture._text).to.equal(newText);


### PR DESCRIPTION
Because `localize` is asynchronous, option `text` may render after `_selectedOptionText` is computed (from `_text`), so notify when it changes.